### PR TITLE
fix: change submit amount and fee types to strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kimafinance/kima-transaction-api",
-  "version": "1.0.30-beta.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kimafinance/kima-transaction-api",
-      "version": "1.0.30-beta.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kimafinance/kima-transaction-api",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A wrapper around Kima's API, enabling sending and monitoring transactions (Beta version)",
   "repository": "https://github.com/kima-finance/kima-transaction-api",
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,8 @@ interface RequestTxProps {
   targetAddress: string;
   originSymbol: CurrencyOptions;
   targetSymbol: CurrencyOptions;
-  amount: number;
-  fee: number;
+  amount: string; // number in whole units i.e. "12.34"
+  fee: string; // number in whole units i.e "0.061234"
   htlcCreationHash: string;
   htlcCreationVout: number;
   htlcExpirationTimestamp: string;


### PR DESCRIPTION
- Avoids rounding errors due to converting back and forth between number types with lots of decimals
- Also the function code just calls `toString()` anyway so better to just make it a string rather than converting to number than back to string again

We Should probably also update the package version to 1.4 to match the others.